### PR TITLE
Changes model API

### DIFF
--- a/src/model/Model.js
+++ b/src/model/Model.js
@@ -5,9 +5,10 @@ export default class Model {
     TOKENS_BEFORE_PREDICTION = 19;
     TOKENS_PREDICTED = 1;
 
-    constructor(predicted_size = 30) {
+    constructor(predicted_size = 30, loading_phrase = 'Loading...') {
         this.model = null;
         this.predicted_size = predicted_size;
+        this.loading_phrase = loading_phrase;
 
         this.ENCODING_DICT = {};
         this.DECODING_DICT = {};
@@ -31,15 +32,18 @@ export default class Model {
     }
 
     argmax(sequence) {
-        return Array.from(sequence)
+        return Array
+            .from(sequence)
             .map((value, index) => [value, index])
             .reduce((x, y) => x[0] > y[0] ? x : y)[1];
     }
 
-    predict(seed) {
+    predict(star_sign) {
         if (this.model === null) {
-            return 'Loading...';
+            return this.loading_phrase;
         }
+
+        const seed = 'Today you will';
 
         const tokenized_text = seed.split(' ').map(word => this.ENCODING_DICT[word]);
         const PREDICT_UNTIL = this.predicted_size + tokenized_text.length;


### PR DESCRIPTION
Changes the API call for the model to allow for more transparency of the end-goal prediction structure. So instead of passing a "seed" now you only pass the star_sing (ideally an int, but we can align later and I can transform it on the model end); the final api is then `model.predict(star_sign)`.

This also changed the constructor API, so [here](https://github.com/brenolf/horoscopus/blob/master/src/index.jsx#L8) you can pass an additional second parameter with the loading phrase, that is displayed when the model hasn't loaded yet. This allows for easier testing, I believe... 